### PR TITLE
Fix the swapped display positions of "Err L" and "Err R"

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,12 +176,12 @@ dl.row dd { font-family: monospace; }
                         <label class="form-check-label ds-i18n" for="checkCircularity">Check circularity</label>
                         <div class="hstack" id="circ-data">
                             <div class="vstack" style="text-align: center;">
-                                <span class="ds-i18n">Err R:</span> 
+                                <span class="ds-i18n">Err L:</span> 
                                 <pre id="el-lbl" style="min-width: 80px;"></pre>
                             </div>
 
                             <div class="vstack" style="text-align: center;">
-                                <span class="ds-i18n">Err L:</span> 
+                                <span class="ds-i18n">Err R:</span> 
                                 <pre id="er-lbl" style="min-width: 80px;"></pre>
                             </div>
                         </div>


### PR DESCRIPTION
Fix the swapped display positions of "Err L" and "Err R" when "Check circularity" is checked