### PR TITLE
fix: dualsense battery status

### DIFF
--- a/core.js
+++ b/core.js
@@ -1462,7 +1462,7 @@ function update_nvs_changes_status(new_value) {
 
 function update_battery_status(bat_capacity, cable_connected, is_charging, is_error) {
     var bat_txt = bat_percent_to_text(bat_capacity, is_charging);
-    var can_use_tool = (bat_capacity >= 30 && cable_connected && !is_error);
+    var can_use_tool = (bat_capacity >= 30 && cable_connected && !is_error); // is this even being used?
 
     if(bat_txt != last_bat_txt) {
         $("#d-bat").html(bat_txt);
@@ -1561,7 +1561,7 @@ function process_ds_input(data) {
     if(bat_status == 0) {
         bat_capacity = Math.min(bat_charge * 10 + 5, 100);
     } else if(bat_status == 1) {
-        bat_capacity = Math.max(bat_charge * 10 + 5, 100);
+        bat_capacity = Math.min(bat_charge * 10 + 5, 100);
         is_charging = true;
         cable_connected = true;
     } else if(bat_status == 2) {


### PR DESCRIPTION
- fixes battery charge level percentage: previously it would show "100%" and charging for dualsense controllers that were not 100%.

- this would also fix the battery safety check if implemented (doesn't look like `can_use_tool` is being used? feel free to remove the comment, i only added to draw attention to that)

i had a bit of a conversation with myself over in the discord which contains a lot of my debuging etc: https://discord.com/channels/1245307680604684341/1362290484504035370