### PR TITLE
Add Xbox controller diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
-# DualShock Calibration GUI
+# Controller Calibration GUI
 
-A web-based calibration tool for PlayStation DualShock 4, DualSense, and DualSense Edge controllers using the WebHID API.
+A web-based controller diagnostics and calibration tool. PlayStation DualShock 4,
+DualSense, and DualSense Edge controllers use WebHID for testing and device
+calibration. Xbox controllers use the standard Gamepad API for live diagnostics
+of sticks, triggers, D-pad, and buttons.
+
+The browser Gamepad API does not expose Xbox firmware calibration commands.
+Permanent Xbox thumbstick and trigger calibration is therefore completed in
+Microsoft's official Xbox Accessories app after diagnosing the controller here.
 
 ## Features
 
-- Controller connection via WebHID API
+- PlayStation connection via WebHID
+- Xbox Wireless Controller and Elite Series 2 detection via the Gamepad API
 - Stick calibration and range calibration
-- Input testing and visualization
+- Live stick, trigger, D-pad, and button testing and visualization
+- Xbox circularity and center diagnostics
+- Haptic vibration testing for supported PlayStation controllers
 - Battery status display
 - Multi-language support (20+ languages)
 - Progressive Web App capabilities
@@ -15,9 +25,9 @@ A web-based calibration tool for PlayStation DualShock 4, DualSense, and DualSen
 
 ### Prerequisites
 
-- Node.js (v16 or higher)
+- Node.js (v18 or higher)
 - npm or yarn
-- Modern browser with WebHID support (Chrome/Edge)
+- Modern browser with WebHID and Gamepad API support (Chrome/Edge recommended)
 
 ### Getting Started
 
@@ -69,9 +79,15 @@ This will:
 
 ### Important Notes
 
-- **HTTPS Required**: The WebHID API requires HTTPS. The development server uses self-signed certificates.
+- **HTTPS Required**: WebHID and some browser controller features require a secure context. The development server uses self-signed certificates.
 - **Browser Security**: You may need to accept the self-signed certificate warning in your browser.
-- **Controller Support**: Only works in browsers with WebHID support (Chrome, Edge, Opera).
+- **Xbox calibration**: Browser diagnostics are supported, but permanent
+  calibration is intentionally handed off to the Xbox Accessories app because
+  the Gamepad API does not expose firmware calibration writes. Xbox vibration
+  testing is omitted because wired rumble is not reliable across browsers and
+  operating systems.
+- **Controller Support**: PlayStation calibration requires WebHID. Xbox testing
+  requires the Gamepad API and a controller exposed as Xbox/XInput by the browser.
 
 ### Project Structure
 

--- a/css/main.css
+++ b/css/main.css
@@ -12,6 +12,169 @@ dl.row dd {
   font-family: monospace;
 }
 
+/* Xbox controller diagram */
+.xbox-controller-diagram {
+  width: min(100%, 440px);
+  margin: 0 auto;
+  color: #17232c;
+  user-select: none;
+}
+
+.xbox-controller-shoulders {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1.4fr 1fr 1fr;
+  gap: 0.4rem;
+  padding: 0 10%;
+  position: relative;
+  z-index: 2;
+}
+
+.xbox-controller-body {
+  position: relative;
+  min-height: 245px;
+  margin-top: -0.25rem;
+  border: 4px solid #3399cc;
+  border-radius: 42% 42% 34% 34% / 28% 28% 52% 52%;
+  background: #7ecbff;
+  box-shadow: inset 0 -12px 0 rgba(0, 0, 0, 0.08);
+}
+
+.xbox-control {
+  --xbox-control-color: #fff;
+  display: grid;
+  place-items: center;
+  background: var(--xbox-control-color);
+  border: 2px solid #3399cc;
+  color: #17232c;
+  font-weight: 800;
+  transition: background-color 0.1s, transform 0.08s;
+}
+
+.xbox-shoulder {
+  min-height: 38px;
+  border-radius: 12px 12px 5px 5px;
+  font-size: 0.78rem;
+  line-height: 1;
+}
+
+.xbox-shoulder small {
+  min-height: 0.7rem;
+  font-size: 0.56rem;
+  font-weight: 700;
+}
+
+.xbox-system {
+  position: absolute;
+  top: 20%;
+  width: 34px;
+  height: 27px;
+  border-radius: 50%;
+  font-size: 0.7rem;
+}
+
+.xbox-view { left: 37%; }
+.xbox-logo {
+  left: calc(50% - 22px);
+  top: 9%;
+  width: 44px;
+  height: 44px;
+  font-size: 0.55rem;
+}
+
+.xbox-control-unavailable {
+  opacity: 0.5;
+  border-style: dashed;
+  cursor: help;
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent,
+    transparent 4px,
+    rgba(23, 35, 44, 0.12) 4px,
+    rgba(23, 35, 44, 0.12) 7px
+  );
+}
+
+.xbox-menu { right: 37%; }
+
+.xbox-stick {
+  position: absolute;
+  width: 70px;
+  height: 70px;
+  border: 7px double #3399cc;
+  border-radius: 50%;
+  background-image: radial-gradient(circle at center, transparent 35%, rgba(51, 153, 204, 0.25) 37%);
+  will-change: transform;
+}
+
+.xbox-left-stick { left: 16%; top: 18%; }
+.xbox-right-stick { right: 30%; bottom: 12%; }
+
+.xbox-dpad {
+  position: absolute;
+  left: 27%;
+  bottom: 10%;
+  width: 88px;
+  height: 88px;
+}
+
+.xbox-dpad-button {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  border-radius: 7px;
+  font-size: 0.63rem;
+}
+
+.xbox-dpad-up { left: 28px; top: 0; }
+.xbox-dpad-right { right: 0; top: 28px; }
+.xbox-dpad-down { left: 28px; bottom: 0; }
+.xbox-dpad-left { left: 0; top: 28px; }
+
+.xbox-face-buttons {
+  position: absolute;
+  right: 10%;
+  top: 18%;
+  width: 112px;
+  height: 112px;
+}
+
+.xbox-face {
+  position: absolute;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+}
+
+.xbox-y { left: 37px; top: 0; color: #8a7100; }
+.xbox-b { right: 0; top: 37px; color: #b62d2d; }
+.xbox-a { left: 37px; bottom: 0; color: #16703d; }
+.xbox-x { left: 0; top: 37px; color: #17689d; }
+
+#quick-test-controller-svg-placeholder .xbox-controller-body {
+  min-height: 220px;
+}
+
+@media (max-width: 420px) {
+  .xbox-controller-body {
+    min-height: 220px;
+  }
+
+  .xbox-stick {
+    width: 58px;
+    height: 58px;
+  }
+
+  .xbox-dpad {
+    left: 25%;
+    transform: scale(0.82);
+  }
+
+  .xbox-face-buttons {
+    right: 7%;
+    transform: scale(0.86);
+  }
+}
+
 #left-stick-card,
 #right-stick-card {
   cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>DualShock Calibration GUI</title>
+<title>Controller Calibration GUI</title>
 
 <link id="bootstrap-css" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
@@ -36,7 +36,7 @@
 <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="shortcut icon" href="/favicon.ico" />
-<meta name="apple-mobile-web-app-title" content="DS Tools" />
+<meta name="apple-mobile-web-app-title" content="Controller Tools" />
 
 <!-- External CSS files -->
 <link rel="stylesheet" href="css/main.css">
@@ -48,7 +48,7 @@
 
   <nav class="navbar bg-body-tertiary navbar-expand-md bg-body-tertiary">
     <div class="container-fluid">
-      <a class="navbar-brand ds-i18n" href="https://dualshock-tools.github.io">DualShock Calibration GUI</a>
+      <a class="navbar-brand ds-i18n" href="https://dualshock-tools.github.io">Controller Calibration GUI</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
@@ -83,7 +83,7 @@
             <span class="ds-i18n">Unsupported browser.</span>
           </p>
           <p class="mb-1">
-            <span class="ds-i18n">Please use a web browser with WebHID support (e.g. Google Chrome or Microsoft Edge) on a PC or Mac.</span>
+            <span class="ds-i18n">Please use a modern browser with WebHID or Gamepad API support on a PC or Mac.</span>
             <span class="ds-i18n">Firefox is supported with the WebHID extension installed.</span>
           </p>
           <p class="mb-0">
@@ -94,11 +94,17 @@
     </div>
 
     <div id="offlinebar" class="vstack p-2" style="display: none;">
-      <p class="ds-i18n">Please connect a DualShock 4, a DualSense, DualSense Edge or VR2 controller to your computer and press Connect.</p>
-      <button id="btnconnect" type="button" class="btn btn-outline-primary" onclick="connect()">
-        <span class="spinner-border spinner-border-sm" style="display: none;" id="connectspinner" aria-hidden="true"></span>
-        <span class="ds-i18n">Connect</span>
-      </button>
+      <p class="ds-i18n">Connect a supported PlayStation or Xbox controller, then choose its family below.</p>
+      <div class="d-grid d-sm-flex gap-2">
+        <button id="btnconnect" type="button" class="btn btn-outline-primary flex-fill" onclick="connect()">
+          <span class="spinner-border spinner-border-sm" style="display: none;" id="connectspinner" aria-hidden="true"></span>
+          <span class="ds-i18n">Connect PlayStation controller</span>
+        </button>
+        <button id="btnconnectxbox" type="button" class="btn btn-outline-success flex-fill" onclick="connectXbox()">
+          <span class="spinner-border spinner-border-sm" style="display: none;" id="connectxboxspinner" aria-hidden="true"></span>
+          <span class="ds-i18n">Connect Xbox controller</span>
+        </button>
+      </div>
       <br>
     </div>
 
@@ -207,6 +213,17 @@
                 <button type="button" class="btn btn-primary ds-btn" onclick="ds5_finetune()" id="ds5finetune">
                   <span class="ds-i18n">Finetune stick calibration</span>
                 </button>
+                <div class="card border-success" id="xbox-calibration-card" style="display: none;">
+                  <div class="card-body">
+                    <h5 class="card-title"><i class="fab fa-xbox me-2"></i><span class="ds-i18n">Xbox calibration</span></h5>
+                    <p class="card-text mb-2 ds-i18n">This page can test sticks, triggers, buttons, circularity, and vibration. Browsers cannot write Xbox calibration values to the controller.</p>
+                    <p class="card-text small text-muted ds-i18n">Use the official Xbox Accessories app on Windows or Xbox for permanent thumbstick and trigger calibration.</p>
+                    <a class="btn btn-success w-100" href="https://apps.microsoft.com/detail/9nblggh30xj3" target="_blank" rel="noopener noreferrer">
+                      <span class="ds-i18n">Open Xbox Accessories</span>
+                      <i class="fas fa-arrow-up-right-from-square ms-2"></i>
+                    </a>
+                  </div>
+                </div>
                 <hr>
                 <button id="savechanges" type="button" class="btn btn-success ds-btn ds-i18n" onclick="flash_all_changes()">Save changes permanently</button>
                 <button id="restore-calibration-btn" type="button" class="btn btn-secondary ds-btn ds-i18n" onclick="openCalibrationHistoryModal()">Restore calibration</button>

--- a/js/controller-manager.js
+++ b/js/controller-manager.js
@@ -143,7 +143,15 @@ class ControllerManager {
   */
   setInputReportHandler(handler) {
     if (!this.currentController) return;
-    this.currentController.device.oninputreport = handler;
+    this.currentController.setInputReportHandler(handler);
+  }
+
+  /**
+   * Start the input stream for the active transport.
+   */
+  startInput() {
+    if (!this.currentController) return;
+    this.currentController.startInput(this.getInputHandler());
   }
 
   /**
@@ -440,20 +448,51 @@ class ControllerManager {
    * @param {Function} doneCb - Callback function called when vibration ends (optional)
    */
   async setVibration({heavyLeft, lightRight, duration = 0}, doneCb = ({success}) => {}) {
-    try {
-      await this.currentController.setVibration(heavyLeft, lightRight);
+    const controller = this.currentController;
+    if (!controller) return { success: false };
 
-      // If duration is specified, automatically turn off vibration after the duration
-      if (duration > 0) {
-        setTimeout(async () => {
-          if(!this.currentController) return doneCb({success: true});
-          await this.currentController.setVibration(0, 0); // Turn off vibration
-          doneCb({success: true});
-        }, duration);
+    try {
+      if (controller.handlesVibrationDuration?.()) {
+        const result = await controller.setVibration(heavyLeft, lightRight, duration);
+        if (result?.success === false) {
+          throw new Error(result.message || 'Vibration is not available');
+        }
+        doneCb({ success: true });
+        return result;
       }
+
+      const result = await controller.setVibration(heavyLeft, lightRight);
+      if (result?.success === false) {
+        throw new Error(result.message || 'Vibration is not available');
+      }
+
+      // HID controllers keep vibrating until another output report stops them.
+      if (duration > 0) {
+        return await new Promise((resolve, reject) => {
+          setTimeout(async () => {
+            if (this.currentController !== controller) {
+              doneCb({ success: true });
+              resolve({ success: true });
+              return;
+            }
+
+            try {
+              await controller.setVibration(0, 0);
+              doneCb({ success: true });
+              resolve({ success: true });
+            } catch (error) {
+              doneCb({ success: false });
+              reject(error);
+            }
+          }, duration);
+        });
+      }
+
+      doneCb({ success: true });
+      return result;
     } catch (error) {
       if(!this.currentController) return; // the controller was unplugged
-      if(duration) doneCb({ success: false});
+      doneCb({ success: false});
       throw new Error(l("Failed to set vibration"), { cause: error });
     }
   }
@@ -563,28 +602,90 @@ class ControllerManager {
   }
 
   /**
+   * Record a W3C Standard Gamepad snapshot using the same state shape as HID
+   * controllers so the rest of the UI stays transport-agnostic.
+   */
+  _recordGamepadStates(gamepad, inputConfig) {
+    const changes = {};
+    const { axes, triggerButtons, buttonMap } = inputConfig;
+    const normalizeAxis = (index) => {
+      const value = gamepad.axes[index] ?? 0;
+      return Math.round(value * 1000) / 1000;
+    };
+
+    const newSticks = {
+      left: {
+        x: normalizeAxis(axes.leftX),
+        y: normalizeAxis(axes.leftY),
+      },
+      right: {
+        x: normalizeAxis(axes.rightX),
+        y: normalizeAxis(axes.rightY),
+      },
+    };
+
+    if (this._sticksChanged(this.button_states.sticks, newSticks)) {
+      this.button_states.sticks = newSticks;
+      changes.sticks = newSticks;
+    }
+
+    [
+      ['l2', triggerButtons.left],
+      ['r2', triggerButtons.right],
+    ].forEach(([name, buttonIndex]) => {
+      const value = Math.round((gamepad.buttons[buttonIndex]?.value || 0) * 255);
+      const key = `${name}_analog`;
+      if (value !== this.button_states[key]) {
+        this.button_states[key] = value;
+        changes[key] = value;
+      }
+    });
+
+    for (const button of buttonMap) {
+      const gamepadButton = gamepad.buttons[button.button];
+      if (!gamepadButton) continue;
+      const pressed = gamepadButton.pressed || gamepadButton.value > 0.5;
+      if (this.button_states[button.name] !== pressed) {
+        this.button_states[button.name] = pressed;
+        changes[button.name] = pressed;
+      }
+    }
+
+    return changes;
+  }
+
+  /**
   * Process controller input data and call callback if set
   * This is the first part of the split process_controller_input function
   * @param {Object} inputData - The input data from the controller
   * @returns {Object} Changes object containing processed input data
   */
   processControllerInput(inputData) {
-    const { data } = inputData;
-
     const inputConfig = this.currentController.getInputConfig();
-    const { buttonMap, dpadByte, l2AnalogByte, r2AnalogByte } = inputConfig;
-    const { touchpadOffset } = inputConfig;
+    const { buttonMap } = inputConfig;
+    let changes;
 
-    // Process button states using the device-specific configuration
-    const changes = this._recordButtonStates(data, buttonMap, dpadByte, l2AnalogByte, r2AnalogByte);
+    if (inputConfig.type === 'gamepad') {
+      changes = this._recordGamepadStates(inputData.gamepad, inputConfig);
+    } else {
+      const { data } = inputData;
+      const { dpadByte, l2AnalogByte, r2AnalogByte } = inputConfig;
+      changes = this._recordButtonStates(data, buttonMap, dpadByte, l2AnalogByte, r2AnalogByte);
+    }
 
     // Parse and store touch points if touchpad data is available
-    if (touchpadOffset) {
-      this.touchPoints = this._parseTouchPoints(data, touchpadOffset);
+    if (inputConfig.touchpadOffset && inputData.data) {
+      this.touchPoints = this._parseTouchPoints(inputData.data, inputConfig.touchpadOffset);
     }
 
     // Parse and store battery status
-    this.batteryStatus = this._parseBatteryStatus(data);
+    this.batteryStatus = this._parseBatteryStatus(inputData.data);
+
+    if (inputConfig.type === 'gamepad' &&
+        Object.keys(changes).length === 0 &&
+        !this.batteryStatus.changed) {
+      return;
+    }
 
     const result = {
       changes,
@@ -628,6 +729,11 @@ class ControllerManager {
   */
   _parseBatteryStatus(data) {
     const batteryInfo = this.currentController.parseBatteryStatus(data);
+    if (batteryInfo.unavailable) {
+      const changed = this._lastBatteryText !== "";
+      this._lastBatteryText = "";
+      return { bat_txt: "", changed, ...batteryInfo };
+    }
     const bat_txt = this._batteryPercentToText(batteryInfo);
 
     const changed = bat_txt !== this._lastBatteryText;

--- a/js/controllers/base-controller.js
+++ b/js/controllers/base-controller.js
@@ -44,7 +44,23 @@ class BaseController {
   * @param {Function} handler Input report handler function
   */
   setInputReportHandler(handler) {
-    this.device.oninputreport = handler;
+    if (this.device) {
+      this.device.oninputreport = handler;
+    }
+  }
+
+  /**
+   * Start streaming input. HID controllers use their inputreport event while
+   * other transports (such as the Gamepad API) can override this method.
+   */
+  startInput(handler) {
+    this.setInputReportHandler(handler);
+  }
+
+  stopInput() {
+    if (this.device) {
+      this.device.oninputreport = null;
+    }
   }
 
   /**
@@ -158,7 +174,11 @@ class BaseController {
     return { success: true, message: "This controller does not support adaptive triggers" };
   }
 
-  async setVibration(heavyLeft = 0, lightRight = 0) {
+  handlesVibrationDuration() {
+    return false;
+  }
+
+  async setVibration(heavyLeft = 0, lightRight = 0, duration = 0) {
     // Default no-op implementation for controllers that don't support vibration
     return { success: true, message: "This controller does not support vibration" };
   }

--- a/js/controllers/controller-factory.js
+++ b/js/controllers/controller-factory.js
@@ -4,6 +4,7 @@ import DS4Controller from './ds4-controller.js';
 import DS5Controller from './ds5-controller.js';
 import DS5EdgeController from './ds5-edge-controller.js';
 import VR2Controller from './vr2-controller.js';
+import XboxController from './xbox-controller.js';
 import { dec2hex } from '../utils.js';
 
 /**
@@ -47,6 +48,10 @@ class ControllerFactory {
       default:
         throw new Error(`Unsupported device: ${dec2hex(device.vendorId)}:${dec2hex(device.productId)}`);
     }
+  }
+
+  static createGamepadControllerInstance(gamepad) {
+    return new XboxController(gamepad);
   }
 
   /**
@@ -126,6 +131,23 @@ class ControllerFactory {
           showCalibrationHistory: false
         };
     }
+  }
+
+  static getXboxUIConfig() {
+    return {
+      showInfo: true,
+      showFinetune: false,
+      showInfoTab: true,
+      showQuickTests: true,
+      showFourStepCalib: false,
+      showQuickCalib: false,
+      showCalibrationHistory: false,
+      showRangeCalibration: false,
+      showSaveChanges: false,
+      showReset: false,
+      showXboxCalibration: true,
+      showDebugTab: false,
+    };
   }
 }
 

--- a/js/controllers/xbox-controller.js
+++ b/js/controllers/xbox-controller.js
@@ -1,0 +1,256 @@
+'use strict';
+
+import BaseController from './base-controller.js';
+import { l } from '../translations.js';
+
+// Xbox controllers use the W3C Standard Gamepad layout. The internal names
+// match the existing shared UI: A/B/X/Y correspond to cross/circle/square/triangle.
+export const XBOX_BUTTON_MAP = [
+  { name: 'cross', button: 0, svg: 'Cross' },       // A
+  { name: 'circle', button: 1, svg: 'Circle' },     // B
+  { name: 'square', button: 2, svg: 'Square' },     // X
+  { name: 'triangle', button: 3, svg: 'Triangle' }, // Y
+  { name: 'l1', button: 4, svg: 'L1' },             // LB
+  { name: 'r1', button: 5, svg: 'R1' },             // RB
+  { name: 'l2', button: 6, svg: 'L2' },             // LT
+  { name: 'r2', button: 7, svg: 'R2' },             // RT
+  { name: 'create', button: 8, svg: 'Create' },     // View
+  { name: 'options', button: 9, svg: 'Options' },   // Menu
+  { name: 'l3', button: 10, svg: 'L3' },
+  { name: 'r3', button: 11, svg: 'R3' },
+  { name: 'up', button: 12 },
+  { name: 'down', button: 13 },
+  { name: 'left', button: 14 },
+  { name: 'right', button: 15 },
+  { name: 'ps', button: 16, svg: 'PS' },             // Xbox button
+];
+
+const XBOX_INPUT_CONFIG = {
+  type: 'gamepad',
+  buttonMap: XBOX_BUTTON_MAP,
+  axes: {
+    leftX: 0,
+    leftY: 1,
+    rightX: 2,
+    rightY: 3,
+  },
+  triggerButtons: {
+    left: 6,
+    right: 7,
+  },
+};
+
+export function isXboxGamepad(gamepad) {
+  if (!gamepad?.connected) return false;
+  const id = gamepad.id || '';
+  return /xbox|xinput|microsoft|vendor:\s*045e|vendor=045e/i.test(id);
+}
+
+/**
+ * Gamepad.id is intentionally browser-defined, so an Xbox controller can have
+ * a generic name. Once the user explicitly chooses the Xbox flow, a standard
+ * two-stick gamepad is a safe compatibility fallback.
+ */
+export function isXboxCompatibleGamepad(gamepad) {
+  if (!gamepad?.connected) return false;
+  if (isXboxGamepad(gamepad)) return true;
+  return gamepad.axes?.length >= 4 && gamepad.buttons?.length >= 16;
+}
+
+function getCurrentGamepad(index) {
+  return navigator.getGamepads?.()[index] || null;
+}
+
+class XboxController extends BaseController {
+  constructor(gamepad) {
+    super(null);
+    this.model = 'XBOX';
+    this.gamepadIndex = gamepad.index;
+    this.gamepadId = gamepad.id || 'Xbox Controller';
+    this.mapping = gamepad.mapping || '';
+    this.animationFrame = null;
+    this.inputCallback = null;
+  }
+
+  getInputConfig() {
+    return XBOX_INPUT_CONFIG;
+  }
+
+  getNumberOfSticks() {
+    return 2;
+  }
+
+  getDevice() {
+    return getCurrentGamepad(this.gamepadIndex);
+  }
+
+  getSerialNumber() {
+    // The Gamepad API deliberately does not expose unique device identifiers.
+    return Promise.resolve(null);
+  }
+
+  async getInfo() {
+    const gamepad = this.getDevice();
+    if (!gamepad?.connected) {
+      return { ok: false, error: new Error('Xbox controller is no longer connected') };
+    }
+
+    const connection = /bluetooth/i.test(gamepad.id) ? 'Bluetooth' : l('USB or wireless');
+    const mapping = gamepad.mapping === 'standard' ? l('Standard gamepad') : (gamepad.mapping || l('Unknown'));
+    return {
+      ok: true,
+      infoItems: [
+        { key: l('Browser interface'), value: 'Gamepad API', cat: 'fw' },
+        { key: l('Input mapping'), value: mapping, cat: 'fw' },
+        { key: l('Connection'), value: connection, cat: 'hw' },
+        { key: l('Axes'), value: String(gamepad.axes.length), cat: 'hw' },
+        { key: l('Buttons'), value: String(gamepad.buttons.length), cat: 'hw' },
+      ],
+      disable_bits: 0,
+    };
+  }
+
+  startInput(handler) {
+    this.inputCallback = handler;
+
+    const poll = () => {
+      const gamepad = this.getDevice();
+      if (!gamepad?.connected || !this.inputCallback) return;
+      this.inputCallback({ gamepad });
+      this.animationFrame = requestAnimationFrame(poll);
+    };
+
+    poll();
+  }
+
+  stopInput() {
+    this.inputCallback = null;
+    if (this.animationFrame !== null) {
+      cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = null;
+    }
+  }
+
+  async close() {
+    this.stopInput();
+  }
+
+  parseBatteryStatus() {
+    // Battery information is not part of the standard Gamepad API.
+    return {
+      charge_level: 100,
+      cable_connected: false,
+      is_charging: false,
+      is_error: false,
+      unavailable: true,
+    };
+  }
+
+  getSupportedQuickTests() {
+    // Wired Xbox rumble is not reliable through the browser Gamepad API, and
+    // the USB interface cannot be claimed while the browser owns it for input.
+    return ['buttons'];
+  }
+
+  getVibrationCapabilities() {
+    const gamepad = this.getDevice();
+    const actuators = [
+      gamepad?.vibrationActuator,
+      ...(gamepad?.hapticActuators ? Array.from(gamepad.hapticActuators) : []),
+    ].filter((actuator, index, values) => actuator && values.indexOf(actuator) === index);
+
+    return actuators.map(actuator => ({
+      actuator,
+      effects: actuator.effects ? Array.from(actuator.effects) : [],
+      type: actuator.type || '',
+      canPlayEffect: typeof actuator.playEffect === 'function',
+      canPulse: typeof actuator.pulse === 'function',
+    }));
+  }
+
+  supportsVibration() {
+    return this.getVibrationCapabilities().some(({ canPlayEffect, canPulse }) => canPlayEffect || canPulse);
+  }
+
+  handlesVibrationDuration() {
+    return true;
+  }
+
+  async setVibration(heavyLeft = 0, lightRight = 0, duration = 500) {
+    const gamepad = this.getDevice();
+    if (!gamepad?.connected) {
+      throw new Error('Xbox controller is no longer connected');
+    }
+
+    const strongMagnitude = Math.max(0, Math.min(1, heavyLeft / 255));
+    const weakMagnitude = Math.max(0, Math.min(1, lightRight / 255));
+    const effectDuration = Math.max(1, duration || 1);
+    const capabilities = this.getVibrationCapabilities();
+
+    for (const capability of capabilities) {
+      const { actuator, effects, type, canPlayEffect } = capability;
+      if (!canPlayEffect) continue;
+
+      if (!strongMagnitude && !weakMagnitude && typeof actuator.reset === 'function') {
+        await actuator.reset();
+        return { success: true, backend: 'reset', result: 'complete' };
+      }
+
+      const advertisedEffects = effects.filter(effect =>
+        ['dual-rumble', 'trigger-rumble', 'vibration'].includes(effect)
+      );
+      const effectCandidates = [
+        ...advertisedEffects,
+        type === 'trigger-rumble' ? 'trigger-rumble' : null,
+        type === 'vibration' ? 'vibration' : null,
+        'dual-rumble',
+      ].filter((effect, index, values) => effect && values.indexOf(effect) === index);
+
+      for (const effect of effectCandidates) {
+        try {
+          const result = await actuator.playEffect(effect, {
+            startDelay: 0,
+            duration: effectDuration,
+            strongMagnitude,
+            weakMagnitude,
+            leftTrigger: 0,
+            rightTrigger: 0,
+          });
+          if (result === false) continue;
+          return {
+            success: result !== 'preempted',
+            backend: `playEffect:${effect}`,
+            result: result ?? 'complete',
+            message: result === 'preempted' ? 'The vibration effect was preempted by the browser.' : undefined,
+          };
+        } catch (error) {
+          if (!['NotSupportedError', 'TypeError'].includes(error?.name)) throw error;
+        }
+      }
+    }
+
+    for (const { actuator, canPulse } of capabilities) {
+      if (!canPulse) continue;
+      const result = await actuator.pulse(
+        Math.max(strongMagnitude, weakMagnitude),
+        strongMagnitude || weakMagnitude ? effectDuration : 1
+      );
+      if (result === false) continue;
+      return {
+        success: true,
+        backend: 'pulse',
+        result: result ?? 'complete',
+      };
+    }
+
+    const exposed = capabilities.length > 0;
+    return {
+      success: false,
+      message: exposed
+        ? 'The browser exposed a haptic actuator but rejected every supported vibration command.'
+        : 'Haptics are not exposed by this browser.',
+    };
+  }
+}
+
+export default XboxController;

--- a/js/controllers/xbox-visual.js
+++ b/js/controllers/xbox-visual.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * Build a controller diagram without depending on a model-specific SVG asset.
+ * The IDs intentionally mirror the PlayStation diagrams so the shared input
+ * renderer and quick-test workflow can drive both layouts.
+ */
+export function createXboxControllerMarkup(prefix = '') {
+  const id = (name) => `${prefix}${name}`;
+
+  return `
+    <div class="xbox-controller-diagram" id="${id('Controller')}" aria-label="Xbox controller input diagram">
+      <div class="xbox-controller-shoulders" aria-hidden="true">
+        <div class="xbox-control xbox-shoulder" id="${id('L2_infill')}">
+          <span>LT</span><small id="${id('L2_percentage')}"></small>
+        </div>
+        <div class="xbox-control xbox-shoulder" id="${id('L1_infill')}">LB</div>
+        <div class="xbox-controller-spacer"></div>
+        <div class="xbox-control xbox-shoulder" id="${id('R1_infill')}">RB</div>
+        <div class="xbox-control xbox-shoulder" id="${id('R2_infill')}">
+          <span>RT</span><small id="${id('R2_percentage')}"></small>
+        </div>
+      </div>
+
+      <div class="xbox-controller-body">
+        <div class="xbox-control xbox-system xbox-view" id="${id('Create_infill')}" title="View">⧉</div>
+        <div
+          class="xbox-control xbox-system xbox-logo xbox-control-unavailable"
+          id="${id('PS_infill')}"
+          title="Xbox/Guide button: reserved by the operating system and not exposed by most browsers"
+          aria-label="Xbox button unavailable to browser"
+        >XBOX</div>
+        <div class="xbox-control xbox-system xbox-menu" id="${id('Options_infill')}" title="Menu">☰</div>
+
+        <div class="xbox-control xbox-stick xbox-left-stick" id="${id('L3_infill')}" title="Left stick">L</div>
+        <div class="xbox-control xbox-stick xbox-right-stick" id="${id('R3_infill')}" title="Right stick">R</div>
+
+        <div class="xbox-dpad" aria-label="D-pad">
+          <div class="xbox-control xbox-dpad-button xbox-dpad-up" id="${id('Up_infill')}">▲</div>
+          <div class="xbox-control xbox-dpad-button xbox-dpad-right" id="${id('Right_infill')}">▶</div>
+          <div class="xbox-control xbox-dpad-button xbox-dpad-down" id="${id('Down_infill')}">▼</div>
+          <div class="xbox-control xbox-dpad-button xbox-dpad-left" id="${id('Left_infill')}">◀</div>
+        </div>
+
+        <div class="xbox-face-buttons" aria-label="Face buttons">
+          <div class="xbox-control xbox-face xbox-y" id="${id('Triangle_infill')}">Y</div>
+          <div class="xbox-control xbox-face xbox-b" id="${id('Circle_infill')}">B</div>
+          <div class="xbox-control xbox-face xbox-a" id="${id('Cross_infill')}">A</div>
+          <div class="xbox-control xbox-face xbox-x" id="${id('Square_infill')}">X</div>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/js/core.js
+++ b/js/core.js
@@ -4,6 +4,8 @@ import { sleep, float_to_str, dec2hex, dec2hex32, lerp_color, initAnalyticsApi, 
 import { Storage } from './storage.js';
 import { initControllerManager } from './controller-manager.js';
 import ControllerFactory from './controllers/controller-factory.js';
+import { isXboxCompatibleGamepad } from './controllers/xbox-controller.js';
+import { createXboxControllerMarkup } from './controllers/xbox-visual.js';
 import { lang_init, l } from './translations.js';
 import { loadAllTemplates } from './template-loader.js';
 import { draw_stick_dial, CIRCULARITY_DATA_SIZE, calculateCircularityError } from './stick-renderer.js';
@@ -48,6 +50,39 @@ const ll_data = new Array(CIRCULARITY_DATA_SIZE);
 const rr_data = new Array(CIRCULARITY_DATA_SIZE);
 
 let controller = null;
+let xboxConnectionTimeout = null;
+let xboxConnectionInterval = null;
+let xboxConnectionInProgress = false;
+let xboxConnectionRequested = false;
+
+function applyDeviceUI({
+  showInfo,
+  showFinetune,
+  showInfoTab,
+  showQuickTests,
+  showFourStepCalib,
+  showQuickCalib,
+  showCalibrationHistory,
+  showRangeCalibration = true,
+  showSaveChanges = true,
+  showReset = true,
+  showXboxCalibration = false,
+  showDebugTab = true,
+}) {
+  $("#infoshowall").toggle(!!showInfo);
+  $("#ds5finetune").toggle(!!showFinetune);
+  $("#info-tab").toggle(!!showInfoTab);
+  $("#quick-tests-div").css("visibility", showQuickTests ? "visible" : "hidden");
+  $("#four-step-center-calib").toggle(!!showFourStepCalib);
+  $("#quick-center-calib").toggle(!!showQuickCalib);
+  $("#quick-center-calib-group").toggle(!!showQuickCalib);
+  $("#restore-calibration-btn").toggle(!!showCalibrationHistory);
+  $("#range-calib-group").toggle(!!showRangeCalibration);
+  $("#savechanges").toggle(!!showSaveChanges);
+  $("#resetBtn").toggle(!!showReset);
+  $("#xbox-calibration-card").toggle(!!showXboxCalibration);
+  $("#debug-tab").toggle(!!showDebugTab);
+}
 
 function gboot() {
   app.gu = crypto.randomUUID();
@@ -133,20 +168,29 @@ function gboot() {
     initializeApp();
   }
 
-  if (!("hid" in navigator)) {
+  const hasHid = "hid" in navigator;
+  const hasGamepad = "getGamepads" in navigator;
+  if (!hasHid && !hasGamepad) {
     $("#offlinebar").hide();
     $("#onlinebar").hide();
     $("#missinghid").show();
     return;
   }
 
+  $("#btnconnect").toggle(hasHid);
+  $("#btnconnectxbox").toggle(hasGamepad);
   $("#offlinebar").show();
   $("#aboutdrift").show();
   updateLastConnectedInfo();
-  navigator.hid.addEventListener("disconnect", handleDisconnectedDevice);
+  navigator.hid?.addEventListener("disconnect", handleDisconnectedDevice);
+  window.addEventListener("gamepadconnected", handleGamepadConnected);
+  window.addEventListener("gamepaddisconnected", handleGamepadDisconnected);
 }
 
 async function connect() {
+  xboxConnectionRequested = false;
+  clearXboxConnectionWait();
+  setXboxWaitingState(false);
   app.gj = crypto.randomUUID();
   initAnalyticsApi(app); // init with gu and jg
 
@@ -203,6 +247,147 @@ async function connect() {
   }
 }
 
+function getConnectedXboxGamepads() {
+  return Array.from(navigator.getGamepads?.() || []).filter(isXboxCompatibleGamepad);
+}
+
+function setXboxWaitingState(waiting) {
+  $("#btnconnectxbox").prop("disabled", waiting);
+  $("#connectxboxspinner").toggle(waiting);
+}
+
+function clearXboxConnectionWait() {
+  clearTimeout(xboxConnectionTimeout);
+  clearInterval(xboxConnectionInterval);
+  xboxConnectionTimeout = null;
+  xboxConnectionInterval = null;
+}
+
+function cancelXboxConnectionWait() {
+  if (!xboxConnectionRequested || controller?.isConnected()) return;
+  clearXboxConnectionWait();
+  xboxConnectionRequested = false;
+  setXboxWaitingState(false);
+  controller = null;
+}
+
+function showXboxConnectionPrompt() {
+  document.getElementById('popupModal')?.addEventListener(
+    'hidden.bs.modal',
+    cancelXboxConnectionWait,
+    { once: true }
+  );
+  show_popup(
+    l("Xbox controllers use the browser's Gamepad interface, which does not show a device chooser. Press A or move a stick now to let the browser expose the USB controller to this page."),
+    false,
+    l("Cancel")
+  );
+}
+
+async function connectXbox() {
+  if (!("getGamepads" in navigator)) {
+    errorAlert(l("This browser does not support the Gamepad API."));
+    return;
+  }
+
+  app.gj = crypto.randomUUID();
+  xboxConnectionRequested = true;
+  initAnalyticsApi(app);
+  la("begin_xbox");
+  reset_circularity_mode();
+  clearAllAlerts();
+
+  controller = initControllerManager({ handleNvStatusUpdate });
+  controller.setInputHandler(handleControllerInput);
+
+  const gamepads = getConnectedXboxGamepads();
+  if (gamepads.length > 1) {
+    xboxConnectionRequested = false;
+    infoAlert(l("Please connect only one controller at time."));
+    controller = null;
+    return;
+  }
+
+  if (gamepads.length === 1) {
+    await continueXboxConnection(gamepads[0]);
+    return;
+  }
+
+  clearXboxConnectionWait();
+  setXboxWaitingState(true);
+  showXboxConnectionPrompt();
+  xboxConnectionInterval = setInterval(async () => {
+    if (xboxConnectionInProgress || controller?.isConnected()) return;
+    const detectedGamepads = getConnectedXboxGamepads();
+    if (detectedGamepads.length === 1) {
+      await continueXboxConnection(detectedGamepads[0]);
+    }
+  }, 250);
+
+  xboxConnectionTimeout = setTimeout(() => {
+    clearXboxConnectionWait();
+    xboxConnectionRequested = false;
+    setXboxWaitingState(false);
+    if (!controller?.isConnected()) {
+      controller = null;
+      show_popup(l("No controller input was detected. Keep the controller connected by USB, reload the page, click Connect Xbox controller, then press A. Chrome or Edge is recommended."));
+    }
+  }, 15_000);
+}
+
+async function continueXboxConnection(gamepad) {
+  if (!xboxConnectionRequested ||
+      !isXboxCompatibleGamepad(gamepad) ||
+      controller?.isConnected() ||
+      xboxConnectionInProgress) return;
+
+  xboxConnectionInProgress = true;
+  clearXboxConnectionWait();
+  setXboxWaitingState(false);
+
+  try {
+    const controllerInstance = ControllerFactory.createGamepadControllerInstance(gamepad);
+    controller.setControllerInstance(controllerInstance);
+    const info = await controllerInstance.getInfo();
+    if (!info?.ok) {
+      throw new Error(l("Failed to connect to device"), { cause: info?.error });
+    }
+
+    applyDeviceUI(ControllerFactory.getXboxUIConfig());
+    const deviceName = gamepad.id || "Xbox Controller";
+    $("#devname").text(deviceName);
+    $("#d-bat").empty();
+    $("#offlinebar").hide();
+    $("#onlinebar").show();
+    $("#mainmenu").show();
+    $("#aboutdrift").hide();
+    $('#controller-tab').tab('show');
+
+    await init_svg_controller(controllerInstance.getModel());
+    render_info_to_dom(info.infoItems);
+
+    Storage.lastConnectedController.set({
+      deviceName,
+      timestamp: new Date().toISOString(),
+    });
+    updateLastConnectedInfo();
+
+    controller.startInput();
+    xboxConnectionRequested = false;
+    bootstrap.Modal.getInstance('#popupModal')?.hide();
+    la("connect_xbox", {
+      mapping: gamepad.mapping,
+      buttons: gamepad.buttons.length,
+      axes: gamepad.axes.length,
+    });
+  } catch (error) {
+    await disconnect();
+    throw error;
+  } finally {
+    xboxConnectionInProgress = false;
+  }
+}
+
 async function continue_connection({data, device}) {
   try {
     if (!controller || controller.isConnected()) {
@@ -217,18 +402,6 @@ async function continue_connection({data, device}) {
       infoAlert(l("The device is connected via Bluetooth. Disconnect and reconnect using a USB cable instead."));
       await disconnect();
       return;
-    }
-
-    // Helper to apply basic UI visibility based on device type
-    function applyDeviceUI({ showInfo, showFinetune, showInfoTab, showQuickTests, showFourStepCalib, showQuickCalib, showCalibrationHistory }) {
-      $("#infoshowall").toggle(!!showInfo);
-      $("#ds5finetune").toggle(!!showFinetune);
-      $("#info-tab").toggle(!!showInfoTab);
-      $("#quick-tests-div").css("visibility", showQuickTests ? "visible" : "hidden");
-      $("#four-step-center-calib").toggle(!!showFourStepCalib);
-      $("#quick-center-calib").toggle(!!showQuickCalib);
-      $("#quick-center-calib-group").toggle(!!showQuickCalib);
-      $("#restore-calibration-btn").toggle(!!showCalibrationHistory);
     }
 
     let controllerInstance = null;
@@ -384,6 +557,10 @@ async function continue_connection({data, device}) {
 
 async function disconnect() {
   la("disconnect");
+  xboxConnectionRequested = false;
+  clearXboxConnectionWait();
+  xboxConnectionInProgress = false;
+  setXboxWaitingState(false);
   if(!controller?.isConnected()) {
     controller = null;
     return;
@@ -449,8 +626,24 @@ function disconnectSync() {
 }
 
 async function handleDisconnectedDevice(e) {
+  if (controller?.getModel() === 'XBOX') return;
   la("disconnected");
   console.log("Disconnected: " + e.device.productName)
+  await disconnect();
+}
+
+async function handleGamepadConnected(event) {
+  if (!xboxConnectionRequested ||
+      !controller ||
+      controller.isConnected() ||
+      !isXboxCompatibleGamepad(event.gamepad)) return;
+  await continueXboxConnection(event.gamepad);
+}
+
+async function handleGamepadDisconnected(event) {
+  const current = controller?.currentController;
+  if (current?.getModel() !== 'XBOX' || current.gamepadIndex !== event.gamepad.index) return;
+  la("disconnected_xbox");
   await disconnect();
 }
 
@@ -509,6 +702,11 @@ function welcome_accepted() {
 
 async function init_svg_controller(model) {
   const svgContainer = document.getElementById('controller-svg-placeholder');
+
+  if (model === 'XBOX') {
+    svgContainer.innerHTML = createXboxControllerMarkup();
+    return;
+  }
 
   // Determine which SVG to load based on controller model
   let svgFileName;
@@ -675,6 +873,16 @@ function refresh_stick_pos() {
         const ds5_r3_group = document.querySelector('g#R3');
         ds5_r3_group?.setAttribute('transform', `translate(${ds5_r3_x - ds5_r3_cx},${ds5_r3_y - ds5_r3_cy}) scale(0.70)`);
         break;
+      case "XBOX":
+        document.getElementById('L3_infill')?.style.setProperty(
+          'transform',
+          `translate(${plx * 9}px, ${ply * 9}px)`
+        );
+        document.getElementById('R3_infill')?.style.setProperty(
+          'transform',
+          `translate(${prx * 9}px, ${pry * 9}px)`
+        );
+        break;
       default:
         return; // Unsupported model, skip
     }
@@ -690,7 +898,8 @@ function refresh_stick_pos() {
 
   const ll_error = calculateCircularityError(ll_data);
   const rr_error = calculateCircularityError(rr_data);
-  const isTooSmall = (ll_error && ll_error < 5 || rr_error && rr_error < 5);
+  const isTooSmall = controller.getModel() !== 'XBOX' &&
+    (ll_error && ll_error < 5 || rr_error && rr_error < 5);
   circularityCheckIcon.style.display = isTooSmall ? 'block' : 'none';
 }
 
@@ -741,6 +950,7 @@ function update_ds_button_svg(changes, BUTTON_MAP) {
   if (!changes || Object.keys(changes).length === 0) return;
 
   const pressedColor = '#1a237e'; // pleasing dark blue
+  const triggerPressedColor = '#287ffa'; // brighter at full LT/RT pressure
 
   // Update L2/R2 analog infill
   for (const trigger of ['l2', 'r2']) {
@@ -748,7 +958,7 @@ function update_ds_button_svg(changes, BUTTON_MAP) {
     if (changes.hasOwnProperty(key)) {
       const val = changes[key];
       const t = val / 255;
-      const color = lerp_color('#ffffff', pressedColor, t);
+      const color = lerp_color('#ffffff', triggerPressedColor, t);
       const svg = trigger.toUpperCase() + '_infill';
       const infill = document.getElementById(svg);
       set_svg_group_color(infill, color);
@@ -786,6 +996,10 @@ function update_ds_button_svg(changes, BUTTON_MAP) {
 
 function set_svg_group_color(group, color) {
   if (group) {
+    if (group.classList.contains('xbox-control')) {
+      group.style.setProperty('--xbox-control-color', color);
+      return;
+    }
     const elements = group.querySelectorAll('path,rect,circle,ellipse,line,polyline,polygon');
     elements.forEach(el => {
       // Set up a smooth transition for fill and stroke if not already set
@@ -850,7 +1064,7 @@ function get_current_test_tab() {
 }
 
 function detectFailedRangeCalibration(changes) {
-  if (!changes.sticks || app.shownRangeCalibrationWarning) return;
+  if (!changes.sticks || app.shownRangeCalibrationWarning || controller?.getModel() === 'XBOX') return;
 
   const { left, right } = changes.sticks;
   const failedCalibration = [left, right].some(({x, y}) => Math.abs(x) + Math.abs(y) == 2);
@@ -1076,12 +1290,13 @@ function appendInfo(key, value, cat, copyable) {
   appendInfoExtra(key, value, cat, copyable);
 }
 
-function show_popup(text, is_html = false) {
+function show_popup(text, is_html = false, actionText = l("OK")) {
   if(is_html) {
     $("#popupBody").html(text);
   } else {
     $("#popupBody").text(text);
   }
+  $("#popupActionButton").text(actionText);
   bootstrap.Modal.getOrCreateInstance('#popupModal').show();
 }
 
@@ -1201,6 +1416,7 @@ function infoAlert(message, duration = 5_000) {
 // Export functions to global scope for HTML onclick handlers
 window.gboot = gboot;
 window.connect = connect;
+window.connectXbox = connectXbox;
 window.disconnect = disconnectSync;
 window.show_faq_modal = show_faq_modal;
 window.show_info_tab = show_info_tab;

--- a/js/modals/quick-test-modal.js
+++ b/js/modals/quick-test-modal.js
@@ -3,6 +3,7 @@
 import { l } from '../translations.js';
 import { la } from '../utils.js';
 import { Storage } from '../storage.js';
+import { createXboxControllerMarkup } from '../controllers/xbox-visual.js';
 
 const TEST_SEQUENCE = ['usb', 'buttons', 'adaptive', 'haptic', 'lights', 'speaker', 'headphone', 'microphone'];
 const TEST_NAMES = {
@@ -233,8 +234,14 @@ export class QuickTestModal {
         const buttonsTestDesc = l('This test checks all controller buttons by requiring you to press each button up to three times.');
         const buttonsInstructions = l('Press each button until they turn green.');
         const buttonsLongPress = l('Long-press [circle] to skip ahead.');
+        const xboxGuideNote = this.controller.getModel() === 'XBOX'
+          ? `<div class="alert alert-secondary mb-3">
+              <i class="fas fa-lock me-2"></i>
+              <span>${l('The Xbox/Guide button is reserved by the operating system, so browsers cannot reliably test it. It is not required to pass this test.')}</span>
+            </div>`
+          : '';
         const restart = l('Restart');
-        return addIcons(`
+        return this._addControllerButtonIcons(`
           <p>${buttonsTestDesc}</p>
           <p><strong>${instructions}:</strong> ${buttonsInstructions}</p>
           <div class="d-flex justify-content-center mb-3">
@@ -246,6 +253,7 @@ export class QuickTestModal {
             <i class="fas fa-info-circle me-2"></i>
             <span>${buttonsLongPress}</span>
           </div>
+          ${xboxGuideNote}
           <div class="d-flex gap-2 mt-3">
             <button type="button" class="btn btn-success" id="buttons-pass-btn" onclick="markTestResult('buttons', true)">
               <i class="fas fa-check me-1"></i><span>${pass}</span>
@@ -265,6 +273,7 @@ export class QuickTestModal {
         return `
           <p>${hapticTestDesc}</p>
           <p><strong>${instructions}:</strong> ${hapticInstructions}</p>
+          <div id="haptic-runtime-status" class="small text-muted" role="status" aria-live="polite"></div>
           <div class="d-flex gap-2 mt-3">
             <button type="button" class="btn btn-success" id="haptic-pass-btn" onclick="markTestResult('haptic', true)">
               <i class="fas fa-check me-1"></i><span>${pass}</span>
@@ -430,7 +439,27 @@ export class QuickTestModal {
       instruction += ' ' + l('Press [triangle] to go back.');
     }
 
-    $instructionsText.html(addIcons(instruction));
+    $instructionsText.html(this._addControllerButtonIcons(instruction));
+  }
+
+  _addControllerButtonIcons(string) {
+    if (this.controller.getModel() !== 'XBOX') {
+      return addIcons(string);
+    }
+
+    const labels = {
+      triangle: 'Y',
+      square: 'X',
+      circle: 'B',
+      cross: 'A',
+    };
+    return Object.entries(labels).reduce(
+      (result, [name, label]) => result.replaceAll(
+        `[${name}]`,
+        `<span class="badge rounded-pill text-bg-dark align-middle">${label}</span>`
+      ),
+      string
+    );
   }
 
   /**
@@ -531,6 +560,13 @@ export class QuickTestModal {
 
     // Determine which SVG to load based on controller model
     const model = this.controller.getModel();
+    if (model === 'XBOX') {
+      svgContainer.innerHTML = createXboxControllerMarkup('qt-');
+      this.svgContainer = svgContainer;
+      this._resetButtonColors();
+      return;
+    }
+
     let svgFileName;
     if (model === 'DS4') {
       svgFileName = 'dualshock-controller.svg';
@@ -610,6 +646,9 @@ export class QuickTestModal {
     if (model === 'DS4') {
       return BUTTONS.filter(button => button !== 'mute');
     }
+    if (model === 'XBOX') {
+      return BUTTONS.filter(button => !['mute', 'touchpad', 'ps'].includes(button));
+    }
     return BUTTONS;
   }
 
@@ -618,6 +657,10 @@ export class QuickTestModal {
    */
   _setSvgGroupColor(group, color) {
     if (group) {
+      if (group.classList.contains('xbox-control')) {
+        group.style.setProperty('--xbox-control-color', color);
+        return;
+      }
       const elements = group.querySelectorAll('path,rect,circle,ellipse,line,polyline,polygon');
       elements.forEach(el => {
         // Set up a smooth transition for fill and stroke if not already set
@@ -744,7 +787,7 @@ export class QuickTestModal {
    * Reset all button colors to light blue
    */
   _resetButtonColors() {
-    Object.keys(BUTTON_INFILL_MAPPING).forEach(button => {
+    this._getAvailableButtons().forEach(button => {
       const buttonElement = this._getQuickTestElement(BUTTON_INFILL_MAPPING[button]);
       this._setSvgGroupColor(buttonElement, 'orange');
     });
@@ -812,12 +855,36 @@ export class QuickTestModal {
    */
   async _startHapticTest() {
     this._startIconAnimation('haptic');
-    await this.controller.setVibration({ heavyLeft: 255, lightRight: 0, duration: 500 }, async () => {
-      await setTimeout(async () => {
-        await this.controller.setVibration({ heavyLeft: 0, lightRight: 255, duration: 500 });
-      }, 500);
-    });
-    setTimeout(() => { this._stopIconAnimation('haptic'); }, 1500); }
+    const status = document.getElementById('haptic-runtime-status');
+    if (status) {
+      status.className = 'small text-muted';
+      status.textContent = l('Testing the heavy vibration motor…');
+    }
+
+    try {
+      const heavyResult = await this.controller.setVibration({ heavyLeft: 255, lightRight: 255, duration: 800 });
+      if (status) status.textContent = l('Testing the light vibration motor…');
+      const lightResult = await this.controller.setVibration({ heavyLeft: 0, lightRight: 255, duration: 600 });
+      if (status) {
+        status.className = 'small text-success';
+        const backend = lightResult?.backend || heavyResult?.backend;
+        status.textContent = backend
+          ? `${l('Vibration commands completed.')} (${backend})`
+          : l('Vibration commands completed.');
+      }
+    } catch (error) {
+      console.warn('Haptic test failed:', error);
+      if (status) {
+        status.className = 'small text-danger';
+        const macHint = /Macintosh|Mac OS X/i.test(navigator.userAgent)
+          ? ` ${l('On macOS, wired Xbox rumble is browser and controller dependent; try Bluetooth if USB does not vibrate.')}`
+          : '';
+        status.textContent = `${l('The browser could not activate controller vibration. Try the latest Chrome or Edge.')}${macHint}`;
+      }
+    } finally {
+      this._stopIconAnimation('haptic');
+    }
+  }
 
   /**
    * Start adaptive trigger test

--- a/js/translations.js
+++ b/js/translations.js
@@ -175,7 +175,7 @@ function lang_translate(target_file, target_lang, target_direction) {
         }
 
         const old_title = lang_orig_text[".title"];
-        document.title = lang_cur[old_title];
+        document.title = lang_cur[old_title]?.[0] || old_title;
         if(lang_cur[".authorMsg"]) {
           $("#authorMsg").html(lang_cur[".authorMsg"]);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "dualshock-calibration-gui",
+    "name": "controller-calibration-gui",
     "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "dualshock-calibration-gui",
+            "name": "controller-calibration-gui",
             "version": "1.0.0",
             "license": "MIT",
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "dualshock-calibration-gui",
+    "name": "controller-calibration-gui",
     "version": "1.0.0",
-    "description": "A web-based calibration tool for PlayStation DualShock 4, DualSense, and DualSense Edge controllers",
+    "description": "A web-based testing and calibration tool for PlayStation and Xbox controllers",
     "main": "index.html",
     "type": "module",
     "scripts": {
@@ -14,7 +14,8 @@
         "serve:https": "HTTPS=true node dev-server.js",
         "start": "npm run build && npm run serve",
         "dev:serve": "npm run build && concurrently \"npm run dev\" \"npm run serve\"",
-        "dev:full": "npm run build && concurrently --kill-others \"npm run watch\" \"npm run serve\""
+        "dev:full": "npm run build && concurrently --kill-others \"npm run watch\" \"npm run serve\"",
+        "test": "node --test tests/*.test.js"
     },
     "devDependencies": {
         "rollup": "^4.9.0",
@@ -47,9 +48,12 @@
     "keywords": [
         "dualshock",
         "dualsense",
+        "xbox",
+        "xinput",
         "controller",
         "calibration",
-        "webHID"
+        "webHID",
+        "gamepad"
     ],
     "author": "",
     "license": "MIT"

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Dualshock Calibration GUI",
-  "short_name": "DS Tools",
+  "name": "Controller Calibration GUI",
+  "short_name": "Controller Tools",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",

--- a/templates/popup-modal.html
+++ b/templates/popup-modal.html
@@ -4,7 +4,7 @@
     <div class="modal-content">
       <div class="modal-body" id="popupBody"></div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+        <button type="button" class="btn btn-primary" id="popupActionButton" data-bs-dismiss="modal">OK</button>
       </div>
     </div>
   </div>

--- a/templates/welcome-modal.html
+++ b/templates/welcome-modal.html
@@ -8,7 +8,7 @@
       <div class="modal-body">
       <p class="ds-i18n">Just few things to know before you can start:</p>
       <ul>
-        <li class="ds-i18n">This website is not affiliated with Sony, PlayStation &amp; co.</li>
+        <li class="ds-i18n">This website is not affiliated with Sony, PlayStation, Microsoft, or Xbox.</li>
         <li class="ds-i18n">This service is provided without warranty. Use at your own risk.</li>
         <li class="ds-i18n">This website uses analytics to improve the service.</li>
         <li class="ds-i18n">Keep the internal battery of the controller connected and ensure it is well charged. If the battery dies during operations, the controller will be damaged and rendered unusable.</li>

--- a/tests/xbox-controller.test.js
+++ b/tests/xbox-controller.test.js
@@ -1,0 +1,174 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.window = globalThis;
+if (!globalThis.navigator) {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {},
+  });
+}
+globalThis.$ = () => ({
+  prop() { return this; },
+  toggleClass() { return this; },
+});
+
+const storage = new Map();
+globalThis.localStorage = {
+  getItem(key) { return storage.get(key) ?? null; },
+  setItem(key, value) { storage.set(key, String(value)); },
+  removeItem(key) { storage.delete(key); },
+};
+
+const { default: XboxController, isXboxGamepad, isXboxCompatibleGamepad } =
+  await import('../js/controllers/xbox-controller.js');
+const { initControllerManager } =
+  await import('../js/controller-manager.js');
+
+function makeGamepad() {
+  const buttons = Array.from({ length: 17 }, () => ({ pressed: false, value: 0 }));
+  buttons[0] = { pressed: true, value: 1 };   // A
+  buttons[6] = { pressed: true, value: 0.5 }; // LT
+  buttons[12] = { pressed: true, value: 1 };  // D-pad up
+
+  return {
+    connected: true,
+    index: 0,
+    id: 'Xbox Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 0b13)',
+    mapping: 'standard',
+    axes: [0.25, -0.5, -1, 1],
+    buttons,
+  };
+}
+
+test('recognizes official Xbox and XInput identifiers', () => {
+  assert.equal(isXboxGamepad(makeGamepad()), true);
+  assert.equal(isXboxGamepad({
+    ...makeGamepad(),
+    id: 'Xbox 360 Controller (XInput STANDARD GAMEPAD)',
+  }), true);
+  assert.equal(isXboxGamepad({
+    ...makeGamepad(),
+    id: 'Generic USB Gamepad',
+  }), false);
+  assert.equal(isXboxCompatibleGamepad({
+    ...makeGamepad(),
+    id: 'Generic USB Gamepad',
+  }), true);
+});
+
+test('maps a standard Xbox snapshot into the shared controller state', () => {
+  const gamepad = makeGamepad();
+  Object.defineProperty(globalThis.navigator, 'getGamepads', {
+    configurable: true,
+    value: () => [gamepad],
+  });
+
+  const manager = initControllerManager();
+  manager.setControllerInstance(new XboxController(gamepad));
+
+  let result;
+  manager.setInputHandler((value) => { result = value; });
+  manager.processControllerInput({ gamepad });
+
+  assert.deepEqual(result.changes.sticks, {
+    left: { x: 0.25, y: -0.5 },
+    right: { x: -1, y: 1 },
+  });
+  assert.equal(result.changes.cross, true);
+  assert.equal(result.changes.up, true);
+  assert.equal(result.changes.l2_analog, 128);
+  assert.equal(result.batteryStatus.unavailable, true);
+  assert.equal(result.batteryStatus.bat_txt, '');
+});
+
+test('uses the requested duration and motor magnitudes for Xbox rumble', async () => {
+  const effects = [];
+  const gamepad = {
+    ...makeGamepad(),
+    vibrationActuator: {
+      effects: ['dual-rumble'],
+      async playEffect(type, parameters) {
+        effects.push({ type, parameters });
+        return 'complete';
+      },
+    },
+  };
+  Object.defineProperty(globalThis.navigator, 'getGamepads', {
+    configurable: true,
+    value: () => [gamepad],
+  });
+
+  const controller = new XboxController(gamepad);
+  const manager = initControllerManager();
+  manager.setControllerInstance(controller);
+  assert.deepEqual(controller.getSupportedQuickTests(), ['buttons']);
+
+  await manager.setVibration({ heavyLeft: 255, lightRight: 128, duration: 650 });
+
+  assert.equal(effects.length, 1);
+  assert.equal(effects[0].type, 'dual-rumble');
+  assert.equal(effects[0].parameters.duration, 650);
+  assert.equal(effects[0].parameters.strongMagnitude, 1);
+  assert.equal(effects[0].parameters.weakMagnitude, 128 / 255);
+});
+
+test('does not offer the Xbox haptic quick test', () => {
+  const gamepad = makeGamepad();
+  Object.defineProperty(globalThis.navigator, 'getGamepads', {
+    configurable: true,
+    value: () => [gamepad],
+  });
+
+  const controller = new XboxController(gamepad);
+  assert.deepEqual(controller.getSupportedQuickTests(), ['buttons']);
+});
+
+test('supports the legacy pulse method on vibrationActuator', async () => {
+  const pulses = [];
+  const gamepad = {
+    ...makeGamepad(),
+    vibrationActuator: {
+      async pulse(magnitude, duration) {
+        pulses.push({ magnitude, duration });
+        return true;
+      },
+    },
+  };
+  Object.defineProperty(globalThis.navigator, 'getGamepads', {
+    configurable: true,
+    value: () => [gamepad],
+  });
+
+  const controller = new XboxController(gamepad);
+  const result = await controller.setVibration(128, 255, 700);
+
+  assert.deepEqual(controller.getSupportedQuickTests(), ['buttons']);
+  assert.equal(result.backend, 'pulse');
+  assert.deepEqual(pulses, [{ magnitude: 1, duration: 700 }]);
+});
+
+test('uses trigger-rumble when it is the actuator-advertised effect', async () => {
+  const effects = [];
+  const gamepad = {
+    ...makeGamepad(),
+    vibrationActuator: {
+      effects: ['trigger-rumble'],
+      async playEffect(type, parameters) {
+        effects.push({ type, parameters });
+        return 'complete';
+      },
+    },
+  };
+  Object.defineProperty(globalThis.navigator, 'getGamepads', {
+    configurable: true,
+    value: () => [gamepad],
+  });
+
+  const controller = new XboxController(gamepad);
+  const result = await controller.setVibration(255, 255, 900);
+
+  assert.equal(result.backend, 'playEffect:trigger-rumble');
+  assert.equal(effects[0].type, 'trigger-rumble');
+  assert.equal(effects[0].parameters.duration, 900);
+});


### PR DESCRIPTION
## Summary
- add Xbox/XInput detection and live input through the browser Gamepad API
- add an Xbox-specific controller diagram with sticks, triggers, D-pad, and button visualization
- integrate Xbox button diagnostics into Quick Test while excluding OS-reserved Guide and unreliable browser vibration tests
- add an Xbox Accessories handoff for permanent calibration
- improve the Xbox connection modal, cancellation, timeout, and spinner behavior
- update documentation, metadata, and automated Xbox mapping tests

## Testing
- npm test
- npm run build:prod

Xbox firmware calibration remains outside the browser because the Gamepad API does not expose calibration writes.